### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/io.github.markummitchell.Engauge_Digitizer.json
+++ b/io.github.markummitchell.Engauge_Digitizer.json
@@ -53,25 +53,7 @@
                                 }
                         ]
                 },
-                {
-                        "name": "openjpeg",
-                        "buildsystem": "cmake-ninja",
-                        "config-opts": [
-                                "-DCMAKE_BUILD_TYPE=Release"
-                        ],
-                        "cleanup": [
-                                "/bin",
-                                "/lib/openjpeg-*",
-                                "*.a"
-                        ],
-                        "sources": [
-                                {
-                                        "type": "archive",
-                                        "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz",
-                                        "sha256": "3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a"
-                                }
-                        ]
-                },
+                "shared-modules/openjpeg/openjpeg.json",
                 {
                         "name": "poppler-data",
                         "buildsystem": "cmake-ninja",

--- a/io.github.markummitchell.Engauge_Digitizer.json
+++ b/io.github.markummitchell.Engauge_Digitizer.json
@@ -12,7 +12,7 @@
                 "--socket=wayland",
                 "--socket=x11",
                 "--share=network",
-                "--filesystem=host",	    
+                "--filesystem=host",
                 "--share=ipc",
                 "--device=dri"
         ],


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also
brings a couple of immediate wins: the latest release has bug and
security fixes, and the cmake/cleanup config should result in a
slightly faster and smaller build.