### PR TITLE
Update org.kde.Platform runtime to version 5.15.

### DIFF
--- a/io.github.markummitchell.Engauge_Digitizer.yml
+++ b/io.github.markummitchell.Engauge_Digitizer.yml
@@ -1,6 +1,6 @@
 app-id: io.github.markummitchell.Engauge_Digitizer
 runtime: org.kde.Platform
-runtime-version: '5.12'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: engauge
 rename-icon: engauge-digitizer
@@ -39,7 +39,7 @@ modules:
   - type: archive
     url: http://www.fftw.org/fftw-3.3.7.tar.gz
     sha256: 3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573
-- shared-modules/openjpeg/openjpeg.yml
+- shared-modules/openjpeg/openjpeg.json
 - name: poppler-data
   buildsystem: cmake-ninja
   builddir: true


### PR DESCRIPTION
This bumps the version of the org.kde.Platform runtime to version 5.15.
I also had to fix the path to shared openjpeg module specification to point to openjpeg.json since there is no openjpeg.yml in the submodule.

Builds and runs fine on my end.