### PR TITLE
Update `org.kde.Platform` to `5.15-22.08`.

### DIFF
--- a/io.github.markummitchell.Engauge_Digitizer.yml
+++ b/io.github.markummitchell.Engauge_Digitizer.yml
@@ -1,6 +1,6 @@
 app-id: io.github.markummitchell.Engauge_Digitizer
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 command: engauge
 rename-icon: engauge-digitizer


### PR DESCRIPTION
The flatpak still uses version `5.15-21.08` of `org.kde.Platform` which is deprecated and unsupported. This PR updates the runtime to `5.15-22.08`.